### PR TITLE
Increase upload size

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -10,6 +10,9 @@ location __PATH__/ {
   proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
   proxy_set_header  X-Forwarded-Host $server_name;
 
+  # set max upload size
+  client_max_body_size 128M;
+
   # Include SSOWAT user panel.
   # include conf.d/yunohost_panel.conf.inc;
 }


### PR DESCRIPTION
## Problem

- By default NGINX has an upload size limit of 1M which can make it difficult to upload images for recipes

## Solution

- We increase the max upload size to 128M to match upstream

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
