### PR TITLE
feat: added "media" permission in manifest.toml

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -63,6 +63,11 @@ ram.runtime = "1500M"
     api.auth_header = false
     api.show_tile = false
     api.protected = true
+    media.url = "/media"
+    media.allowed = "visitors"
+    media.auth_header = false
+    media.show_tile = false
+    media.protected = true
 
     [resources.ports]
     main.default = 8095


### PR DESCRIPTION
## Problem

Hi there! 😄 

I am the developer of [kitshn](https://github.com/aimok04/kitshn), a third-party application for Tandoor Recipes that uses the API.

Recently, a user opened an issue (https://github.com/aimok04/kitshn/issues/165), because the recipe cover images weren't loading inside the app. 
I am very unexperienced with Yunohost, so I tried it out and found out that by default, this package only exposes the /api* endpoints.

## Solution

Add a new permission for media endpoints:
```
    media.url = "/media"
    media.allowed = "visitors" # idk if it is a good idea to expose this by default 🤷
    media.auth_header = false
    media.show_tile = false
    media.protected = true
```

Thank you for your work! 🙌

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
