### PR TITLE
[autopatch] Autopatch to use timedatectl instead of legacy /etc/timezone

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -6,7 +6,7 @@
 
 nodejs_version="16"
 
-timezone="$(cat /etc/timezone)"
+timezone="$(timedatectl show --value --property=Timezone)"
 
 _tandoor_venv_install() {
     ynh_hide_warnings ynh_exec_as_app python3 -m venv --upgrade "$install_dir/venv"

--- a/scripts/install
+++ b/scripts/install
@@ -12,7 +12,7 @@ source /usr/share/yunohost/helpers
 #=================================================
 
 version=$(ynh_app_upstream_version)
-timezone="$(cat /etc/timezone)"
+timezone="$(timedatectl show --value --property=Timezone)"
 secretkey=$(ynh_string_random --length=12)
 ynh_app_setting_set --key=secretkey --value="$secretkey"
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -11,7 +11,7 @@ source /usr/share/yunohost/helpers
 # INITIALIZE AND STORE SETTINGS
 #=================================================
 
-timezone="$(cat /etc/timezone)"
+timezone="$(timedatectl show --value --property=Timezone)"
 version=$(ynh_app_upstream_version)
 
 #=================================================


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** fix to use the timedatectl command instead of
`cat /etc/timezone`.